### PR TITLE
fix: dark 테마 제거, technical.md draft 정리

### DIFF
--- a/docs/technical.md
+++ b/docs/technical.md
@@ -1,9 +1,3 @@
-# git-jandi — technical.md (draft)
-
-> repo 루트에 배치할 기술 설계 문서. 프로젝트 생성 시 이 내용을 `~/dev/git-jandi/technical.md`로 복사.
-
----
-
 # Technical Design
 
 ## 데이터 흐름
@@ -115,25 +109,17 @@ export function calculateStreak(weeks: WeekData[]): StreakInfo
 ### colors.ts
 
 ```typescript
-export const THEMES: Record<string, Theme> = { dark: ..., light: ... }
-export function getDefaultTheme(): Theme
+export const THEME: Theme = { colors: ['#ebedf0', '#9be9a8', '#40c463', '#30a14e', '#216e39'] }
 ```
 
 **역할:** contribution level → 터미널 색상 매핑
 
-**테마:**
+**테마:** GitHub light 모드 기준 단일 테마
 ```typescript
-const dark: Theme = {
-  colors: ['#161b22', '#0e4429', '#006d32', '#26a641', '#39d353']
-};
-
-const light: Theme = {
+const THEME: Theme = {
   colors: ['#ebedf0', '#9be9a8', '#40c463', '#30a14e', '#216e39']
 };
 ```
-
-**기본 테마 선택:** `dark` 고정 (대부분의 터미널이 다크 배경)
-- `--light` 옵션으로 전환
 
 ### render.ts
 
@@ -181,7 +167,6 @@ function hexToAnsi(hex: string): string {
 **인자 파싱:** 직접 구현 (외부 라이브러리 없음) — 인자가 단순하므로
 - `argv[2]` → username (필수)
 - `--no-streak` / `-s` → streak 숨기기
-- `--light` → 라이트 테마
 - `--help` / `-h` → 도움말
 - `--version` / `-v` → 버전
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "git-jandi",
-  "version": "1.0.0",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "git-jandi",
-      "version": "1.0.0",
+      "version": "0.0.2",
       "license": "MIT",
       "bin": {
         "git-jandi": "dist/index.js"

--- a/src/colors.ts
+++ b/src/colors.ts
@@ -1,17 +1,8 @@
 import type { Theme } from "./types.js";
 
-export const THEMES: Record<string, Theme> = {
-  dark: {
-    colors: ["#ebedf0", "#9be9a8", "#40c463", "#30a14e", "#216e39"],
-  },
-  light: {
-    colors: ["#161b22", "#0e4429", "#006d32", "#26a641", "#39d353"],
-  },
+export const THEME: Theme = {
+  colors: ["#ebedf0", "#9be9a8", "#40c463", "#30a14e", "#216e39"],
 };
-
-export function getTheme(name: string): Theme {
-  return THEMES[name] ?? THEMES.dark;
-}
 
 /** hex "#rrggbb" → ANSI truecolor foreground escape */
 export function hexToAnsi(hex: string): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 
 import { fetchContributions } from "./fetch.js";
 import { calculateStreak } from "./streak.js";
-import { getTheme } from "./colors.js";
+import { THEME } from "./colors.js";
 import { renderGraph } from "./render.js";
 
 const VERSION = "0.0.1";
@@ -10,7 +10,6 @@ const VERSION = "0.0.1";
 interface Options {
   username: string;
   hideStreak: boolean;
-  theme: string;
 }
 
 function printHelp(): void {
@@ -22,13 +21,11 @@ Usage:
 
 Options:
   --no-streak, -s    Hide streak information
-  --light            Use light theme colors
   --help, -h         Show this help
   --version, -v      Show version
 
 Examples:
   git-jandi leafbird
-  git-jandi torvalds --light
   npx git-jandi octocat
 `.trim());
 }
@@ -56,7 +53,6 @@ function parseArgs(argv: string[]): Options | null {
   return {
     username,
     hideStreak: args.includes("--no-streak") || args.includes("-s"),
-    theme: args.includes("--light") ? "light" : "dark",
   };
 }
 
@@ -67,8 +63,7 @@ async function main(): Promise<void> {
   try {
     const data = await fetchContributions(opts.username);
     const streak = calculateStreak(data.weeks);
-    const theme = getTheme(opts.theme);
-    const output = renderGraph(data, streak, theme, opts.hideStreak);
+    const output = renderGraph(data, streak, THEME, opts.hideStreak);
     console.log(output);
   } catch (err) {
     console.error(err instanceof Error ? err.message : String(err));

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { renderGraph } from "../src/render.js";
-import { THEMES } from "../src/colors.js";
+import { THEME } from "../src/colors.js";
 import type { ContributionData, StreakInfo } from "../src/types.js";
 
 function makeTestData(): ContributionData {
@@ -26,47 +26,47 @@ const streak: StreakInfo = { current: 5, max: 10 };
 
 describe("renderGraph", () => {
   it("총 contribution 수가 출력에 포함된다", () => {
-    const output = renderGraph(makeTestData(), streak, THEMES.dark, false);
+    const output = renderGraph(makeTestData(), streak, THEME, false);
     expect(output).toContain("42");
     expect(output).toContain("contributions in the last year");
   });
 
   it("streak 정보가 포함된다", () => {
-    const output = renderGraph(makeTestData(), streak, THEMES.dark, false);
+    const output = renderGraph(makeTestData(), streak, THEME, false);
     expect(output).toContain("Current streak: 5");
     expect(output).toContain("Max streak: 10");
   });
 
   it("hideStreak=true이면 streak이 출력되지 않는다", () => {
-    const output = renderGraph(makeTestData(), streak, THEMES.dark, true);
+    const output = renderGraph(makeTestData(), streak, THEME, true);
     expect(output).not.toContain("Current streak");
     expect(output).not.toContain("Max streak");
   });
 
   it("범례가 포함된다", () => {
-    const output = renderGraph(makeTestData(), streak, THEMES.dark, false);
+    const output = renderGraph(makeTestData(), streak, THEME, false);
     expect(output).toContain("Less");
     expect(output).toContain("More");
   });
 
   it("■ 블록 문자가 포함된다", () => {
-    const output = renderGraph(makeTestData(), streak, THEMES.dark, false);
+    const output = renderGraph(makeTestData(), streak, THEME, false);
     expect(output).toContain("■");
   });
 
   it("월 레이블이 포함된다", () => {
-    const output = renderGraph(makeTestData(), streak, THEMES.dark, false);
+    const output = renderGraph(makeTestData(), streak, THEME, false);
     expect(output).toContain("Jan");
   });
 
   it("ANSI 색상 코드가 포함된다", () => {
-    const output = renderGraph(makeTestData(), streak, THEMES.dark, false);
+    const output = renderGraph(makeTestData(), streak, THEME, false);
     // truecolor escape: \x1b[38;2;R;G;Bm
     expect(output).toMatch(/\x1b\[38;2;\d+;\d+;\d+m/);
   });
 
-  it("라이트 테마도 정상 렌더링된다", () => {
-    const output = renderGraph(makeTestData(), streak, THEMES.light, false);
+  it("단일 테마로 정상 렌더링된다", () => {
+    const output = renderGraph(makeTestData(), streak, THEME, false);
     expect(output).toContain("■");
     expect(output).toContain("42");
   });


### PR DESCRIPTION
## 변경 내용

### 1. docs/technical.md draft 메모 제거
- 맨 위의 draft 제목과 메모 6줄 삭제

### 2. 기본 테마를 light로 통일
- 기존 `THEMES` (dark/light) → 단일 `THEME` 상수로 변경
- GitHub light 모드 색상 사용: `#ebedf0, #9be9a8, #40c463, #30a14e, #216e39`
- 기존 코드에서 dark/light 키의 색상이 서로 뒤바뀌어 있던 문제도 함께 해소

### 3. dark 테마 및 --light 옵션 제거
- dark 테마 제거 (향후 컬러테마 다분화는 별도 이슈에서)
- 테마가 하나뿐이므로 `--light` CLI 옵션도 제거
- `getTheme()` 함수 제거, `THEME` 상수 직접 참조

Fixes #1