### PR TITLE
feat: GraphQL API support with fallback chain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "git-jandi",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "git-jandi",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "bin": {
         "git-jandi": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-jandi",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Display GitHub contribution graphs in your terminal 🌱",
   "main": "dist/index.js",
   "bin": {

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,12 +1,140 @@
+import { execSync } from "child_process";
 import type { ContributionData, DayData, WeekData } from "./types.js";
 
 const CONTRIBUTIONS_URL = "https://github.com/users/{username}/contributions";
+const GRAPHQL_URL = "https://api.github.com/graphql";
+
+const GRAPHQL_QUERY = `
+query($userName: String!) {
+  user(login: $userName) {
+    contributionsCollection {
+      contributionCalendar {
+        totalContributions
+        weeks {
+          contributionDays {
+            contributionCount
+            date
+            color
+          }
+        }
+      }
+    }
+  }
+}`;
+
+/** GitHub contribution 색상 → level(0-4) 매핑 */
+export const COLOR_TO_LEVEL: Record<string, number> = {
+  "#ebedf0": 0,
+  "#9be9a8": 1,
+  "#40c463": 2,
+  "#30a14e": 3,
+  "#216e39": 4,
+};
+
+interface GraphQLResponse {
+  data?: {
+    user?: {
+      contributionsCollection: {
+        contributionCalendar: {
+          totalContributions: number;
+          weeks: Array<{
+            contributionDays: Array<{
+              contributionCount: number;
+              date: string;
+              color: string;
+            }>;
+          }>;
+        };
+      };
+    };
+  };
+  errors?: Array<{ message: string }>;
+}
 
 /**
- * GitHub contributions 페이지를 가져와 파싱한다.
- * 토큰 불필요 — public HTML 스크래핑.
+ * 토큰을 확보하여 GraphQL API로 가져오거나, 실패 시 HTML 스크래핑으로 fallback.
+ * 토큰 확보 순서: GITHUB_TOKEN 환경변수 → gh auth token 명령어
  */
 export async function fetchContributions(
+  username: string
+): Promise<ContributionData> {
+  const token = process.env.GITHUB_TOKEN ?? getGhAuthToken();
+  if (token) {
+    return fetchContributionsGraphQL(username, token);
+  }
+  return fetchContributionsHTML(username);
+}
+
+/** gh CLI에서 인증 토큰을 가져온다. 실패 시 null 반환. */
+function getGhAuthToken(): string | null {
+  try {
+    return execSync("gh auth token", { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchContributionsGraphQL(
+  username: string,
+  token: string
+): Promise<ContributionData> {
+  let json: GraphQLResponse;
+  try {
+    const res = await fetch(GRAPHQL_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `bearer ${token}`,
+        "Content-Type": "application/json",
+        "User-Agent": "git-jandi",
+      },
+      body: JSON.stringify({
+        query: GRAPHQL_QUERY,
+        variables: { userName: username },
+      }),
+    });
+
+    if (res.status === 401) {
+      throw new Error(
+        "Invalid GITHUB_TOKEN. Check your token and try again."
+      );
+    }
+    if (!res.ok) {
+      throw new Error(`GitHub API error: HTTP ${res.status}`);
+    }
+
+    json = (await res.json()) as GraphQLResponse;
+  } catch (err) {
+    if (err instanceof Error && err.message.includes("GITHUB_TOKEN"))
+      throw err;
+    if (err instanceof Error && err.message.includes("GitHub API"))
+      throw err;
+    throw new Error(
+      "Failed to fetch contributions. Check your network connection."
+    );
+  }
+
+  if (json.errors?.length) {
+    throw new Error(`GitHub API error: ${json.errors[0].message}`);
+  }
+
+  if (!json.data?.user) {
+    throw new Error(`User "${username}" not found`);
+  }
+
+  const calendar =
+    json.data.user.contributionsCollection.contributionCalendar;
+
+  const weeks: WeekData[] = calendar.weeks.map((week) =>
+    week.contributionDays.map((day) => ({
+      date: day.date,
+      level: COLOR_TO_LEVEL[day.color] ?? 0,
+    }))
+  );
+
+  return { total: calendar.totalContributions, weeks, source: "graphql" };
+}
+
+async function fetchContributionsHTML(
   username: string
 ): Promise<ContributionData> {
   const url = CONTRIBUTIONS_URL.replace("{username}", username);
@@ -82,5 +210,5 @@ export function parseHTML(html: string): ContributionData {
     weeks.push(currentWeek);
   }
 
-  return { total, weeks };
+  return { total, weeks, source: "html" };
 }

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -52,16 +52,30 @@ interface GraphQLResponse {
 }
 
 /**
- * 토큰을 확보하여 GraphQL API로 가져오거나, 실패 시 HTML 스크래핑으로 fallback.
- * 토큰 확보 순서: GITHUB_TOKEN 환경변수 → gh auth token 명령어
+ * 토큰을 확보하여 GraphQL API로 가져오거나, 실패 시 다음 단계로 fallback.
+ * 순서: GITHUB_TOKEN → gh auth token → HTML scraping
  */
 export async function fetchContributions(
   username: string
 ): Promise<ContributionData> {
-  const token = process.env.GITHUB_TOKEN ?? getGhAuthToken();
-  if (token) {
-    return fetchContributionsGraphQL(username, token);
+  const envToken = process.env.GITHUB_TOKEN;
+  if (envToken) {
+    try {
+      return await fetchContributionsGraphQL(username, envToken);
+    } catch {
+      // GITHUB_TOKEN 실패 → gh auth token으로 fallback
+    }
   }
+
+  const ghToken = getGhAuthToken();
+  if (ghToken) {
+    try {
+      return await fetchContributionsGraphQL(username, ghToken);
+    } catch {
+      // gh auth token 실패 → HTML로 fallback
+    }
+  }
+
   return fetchContributionsHTML(username);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { calculateStreak } from "./streak.js";
 import { THEME } from "./colors.js";
 import { renderGraph } from "./render.js";
 
-const VERSION = "0.0.1";
+const VERSION = "0.0.3";
 
 interface Options {
   username: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,8 +24,14 @@ Options:
   --help, -h         Show this help
   --version, -v      Show version
 
+Data source (in priority order):
+  1. GITHUB_TOKEN env   GitHub GraphQL API (real-time)
+  2. gh auth token      GitHub GraphQL API via GitHub CLI
+  3. (fallback)         HTML scraping (may be cached by CDN)
+
 Examples:
   git-jandi leafbird
+  GITHUB_TOKEN=ghp_xxx git-jandi leafbird
   npx git-jandi octocat
 `.trim());
 }

--- a/src/render.ts
+++ b/src/render.ts
@@ -61,11 +61,13 @@ export function renderGraph(
     lines.push(line);
   }
 
-  // 범례
+  // 범례 + 데이터 소스
   const legendWidth = colCount * 2;
+  const sourceLabel = data.source === "graphql" ? "via GitHub API" : "via HTML scraping";
   const legendContent = buildLegend(theme);
-  const padding = Math.max(0, legendWidth - stripAnsi(legendContent).length);
-  lines.push(" ".repeat(padding) + legendContent);
+  const bottomRight = legendContent + "  " + sourceLabel;
+  const padding = Math.max(0, legendWidth - stripAnsi(bottomRight).length);
+  lines.push(" ".repeat(padding) + bottomRight);
 
   return lines.join("\n");
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,10 +7,14 @@ export interface DayData {
 /** 주 단위 (일~토, 최대 7일) */
 export type WeekData = DayData[];
 
+/** 데이터 소스 */
+export type DataSource = "graphql" | "html";
+
 /** fetch 결과 전체 */
 export interface ContributionData {
   total: number;       // 총 contribution 수
   weeks: WeekData[];   // 53주 분량
+  source: DataSource;  // 데이터 획득 방식
 }
 
 /** streak 계산 결과 */

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -1,13 +1,22 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { readFileSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
-import { parseHTML } from "../src/fetch.js";
+import * as child_process from "child_process";
+import { fetchContributions, parseHTML, COLOR_TO_LEVEL } from "../src/fetch.js";
+
+vi.mock("child_process", async () => {
+  const actual = await vi.importActual<typeof child_process>("child_process");
+  return { ...actual, execSync: vi.fn() };
+});
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const fixtureHTML = readFileSync(
   join(__dirname, "fixtures/contributions.html"),
   "utf-8"
+);
+const fixtureGraphQL = JSON.parse(
+  readFileSync(join(__dirname, "fixtures/graphql-response.json"), "utf-8")
 );
 
 describe("parseHTML", () => {
@@ -63,5 +72,192 @@ describe("parseHTML", () => {
     expect(() => parseHTML("<html></html>")).toThrow(
       "Failed to parse contribution data"
     );
+  });
+});
+
+describe("COLOR_TO_LEVEL", () => {
+  it("GitHub 기본 5색을 level 0-4로 매핑한다", () => {
+    expect(COLOR_TO_LEVEL["#ebedf0"]).toBe(0);
+    expect(COLOR_TO_LEVEL["#9be9a8"]).toBe(1);
+    expect(COLOR_TO_LEVEL["#40c463"]).toBe(2);
+    expect(COLOR_TO_LEVEL["#30a14e"]).toBe(3);
+    expect(COLOR_TO_LEVEL["#216e39"]).toBe(4);
+  });
+});
+
+describe("fetchContributions (GraphQL)", () => {
+  const originalToken = process.env.GITHUB_TOKEN;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalToken !== undefined) {
+      process.env.GITHUB_TOKEN = originalToken;
+    } else {
+      delete process.env.GITHUB_TOKEN;
+    }
+  });
+
+  it("GITHUB_TOKEN이 있으면 GraphQL API를 호출한다", async () => {
+    process.env.GITHUB_TOKEN = "test-token";
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(fixtureGraphQL),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const data = await fetchContributions("leafbird");
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.github.com/graphql");
+    expect((options.headers as Record<string, string>).Authorization).toBe(
+      "bearer test-token"
+    );
+  });
+
+  it("GITHUB_TOKEN이 없고 gh CLI도 없으면 HTML 스크래핑을 사용한다", async () => {
+    delete process.env.GITHUB_TOKEN;
+    vi.mocked(child_process.execSync).mockImplementation(() => {
+      throw new Error("command not found: gh");
+    });
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(fixtureHTML),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await fetchContributions("leafbird");
+
+    const [url] = mockFetch.mock.calls[0] as [string];
+    expect(url).toContain("github.com/users/leafbird/contributions");
+  });
+
+  it("GraphQL 응답을 ContributionData로 올바르게 변환한다", async () => {
+    process.env.GITHUB_TOKEN = "test-token";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(fixtureGraphQL),
+      })
+    );
+
+    const data = await fetchContributions("leafbird");
+
+    expect(data.total).toBe(542);
+    expect(data.weeks).toHaveLength(3);
+    expect(data.weeks[0]).toHaveLength(7);
+    expect(data.weeks[2]).toHaveLength(3); // 불완전한 마지막 주
+
+    // level 매핑 확인
+    expect(data.weeks[0][0].level).toBe(0); // #ebedf0
+    expect(data.weeks[0][1].level).toBe(1); // #9be9a8
+    expect(data.weeks[0][2].level).toBe(2); // #40c463
+    expect(data.weeks[0][4].level).toBe(3); // #30a14e
+    expect(data.weeks[0][5].level).toBe(4); // #216e39
+  });
+
+  it("401 응답이면 토큰 에러를 던진다", async () => {
+    process.env.GITHUB_TOKEN = "bad-token";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+      })
+    );
+
+    await expect(fetchContributions("leafbird")).rejects.toThrow(
+      "Invalid GITHUB_TOKEN"
+    );
+  });
+
+  it("존재하지 않는 사용자이면 에러를 던진다", async () => {
+    process.env.GITHUB_TOKEN = "test-token";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ data: { user: null } }),
+      })
+    );
+
+    await expect(fetchContributions("nobody")).rejects.toThrow("not found");
+  });
+
+  it("GraphQL 에러 응답이면 에러를 던진다", async () => {
+    process.env.GITHUB_TOKEN = "test-token";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            errors: [{ message: "Something went wrong" }],
+          }),
+      })
+    );
+
+    await expect(fetchContributions("leafbird")).rejects.toThrow(
+      "Something went wrong"
+    );
+  });
+
+  it("GITHUB_TOKEN 없어도 gh auth token으로 토큰을 확보하면 GraphQL을 사용한다", async () => {
+    delete process.env.GITHUB_TOKEN;
+    vi.mocked(child_process.execSync).mockReturnValue("ghp_from_gh_cli\n");
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(fixtureGraphQL),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const data = await fetchContributions("leafbird");
+
+    const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.github.com/graphql");
+    expect((options.headers as Record<string, string>).Authorization).toBe(
+      "bearer ghp_from_gh_cli"
+    );
+    expect(data.source).toBe("graphql");
+  });
+
+  it("source 필드가 GraphQL이면 'graphql'이다", async () => {
+    process.env.GITHUB_TOKEN = "test-token";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(fixtureGraphQL),
+      })
+    );
+
+    const data = await fetchContributions("leafbird");
+    expect(data.source).toBe("graphql");
+  });
+
+  it("source 필드가 HTML이면 'html'이다", async () => {
+    delete process.env.GITHUB_TOKEN;
+    vi.mocked(child_process.execSync).mockImplementation(() => {
+      throw new Error("command not found: gh");
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(fixtureHTML),
+      })
+    );
+
+    const data = await fetchContributions("leafbird");
+    expect(data.source).toBe("html");
   });
 });

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -160,52 +160,58 @@ describe("fetchContributions (GraphQL)", () => {
     expect(data.weeks[0][5].level).toBe(4); // #216e39
   });
 
-  it("401 응답이면 토큰 에러를 던진다", async () => {
+  it("GITHUB_TOKEN 401 실패 시 gh auth token으로 fallback한다", async () => {
     process.env.GITHUB_TOKEN = "bad-token";
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: false,
-        status: 401,
-      })
-    );
-
-    await expect(fetchContributions("leafbird")).rejects.toThrow(
-      "Invalid GITHUB_TOKEN"
-    );
-  });
-
-  it("존재하지 않는 사용자이면 에러를 던진다", async () => {
-    process.env.GITHUB_TOKEN = "test-token";
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
+    vi.mocked(child_process.execSync).mockReturnValue("ghp_good_token\n");
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({ ok: false, status: 401 })  // env token 실패
+      .mockResolvedValueOnce({                              // gh token 성공
         ok: true,
         status: 200,
-        json: () => Promise.resolve({ data: { user: null } }),
-      })
-    );
+        json: () => Promise.resolve(fixtureGraphQL),
+      });
+    vi.stubGlobal("fetch", mockFetch);
 
-    await expect(fetchContributions("nobody")).rejects.toThrow("not found");
+    const data = await fetchContributions("leafbird");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(data.source).toBe("graphql");
   });
 
-  it("GraphQL 에러 응답이면 에러를 던진다", async () => {
-    process.env.GITHUB_TOKEN = "test-token";
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
+  it("GraphQL 모두 실패 시 HTML로 fallback한다", async () => {
+    process.env.GITHUB_TOKEN = "bad-token";
+    vi.mocked(child_process.execSync).mockReturnValue("ghp_also_bad\n");
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({ ok: false, status: 401 })  // env token 실패
+      .mockResolvedValueOnce({ ok: false, status: 401 })  // gh token 실패
+      .mockResolvedValueOnce({                              // HTML fallback
         ok: true,
         status: 200,
-        json: () =>
-          Promise.resolve({
-            errors: [{ message: "Something went wrong" }],
-          }),
-      })
-    );
+        text: () => Promise.resolve(fixtureHTML),
+      });
+    vi.stubGlobal("fetch", mockFetch);
 
-    await expect(fetchContributions("leafbird")).rejects.toThrow(
-      "Something went wrong"
-    );
+    const data = await fetchContributions("leafbird");
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(data.source).toBe("html");
+  });
+
+  it("gh CLI 없고 env token 실패 시 HTML로 fallback한다", async () => {
+    process.env.GITHUB_TOKEN = "bad-token";
+    vi.mocked(child_process.execSync).mockImplementation(() => {
+      throw new Error("command not found: gh");
+    });
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({ ok: false, status: 401 })  // env token 실패
+      .mockResolvedValueOnce({                              // HTML fallback
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(fixtureHTML),
+      });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const data = await fetchContributions("leafbird");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(data.source).toBe("html");
   });
 
   it("GITHUB_TOKEN 없어도 gh auth token으로 토큰을 확보하면 GraphQL을 사용한다", async () => {

--- a/test/fixtures/graphql-response.json
+++ b/test/fixtures/graphql-response.json
@@ -1,0 +1,42 @@
+{
+  "data": {
+    "user": {
+      "contributionsCollection": {
+        "contributionCalendar": {
+          "totalContributions": 542,
+          "weeks": [
+            {
+              "contributionDays": [
+                { "contributionCount": 0, "date": "2024-03-17", "color": "#ebedf0" },
+                { "contributionCount": 2, "date": "2024-03-18", "color": "#9be9a8" },
+                { "contributionCount": 5, "date": "2024-03-19", "color": "#40c463" },
+                { "contributionCount": 0, "date": "2024-03-20", "color": "#ebedf0" },
+                { "contributionCount": 8, "date": "2024-03-21", "color": "#30a14e" },
+                { "contributionCount": 12, "date": "2024-03-22", "color": "#216e39" },
+                { "contributionCount": 1, "date": "2024-03-23", "color": "#9be9a8" }
+              ]
+            },
+            {
+              "contributionDays": [
+                { "contributionCount": 0, "date": "2024-03-24", "color": "#ebedf0" },
+                { "contributionCount": 0, "date": "2024-03-25", "color": "#ebedf0" },
+                { "contributionCount": 3, "date": "2024-03-26", "color": "#9be9a8" },
+                { "contributionCount": 7, "date": "2024-03-27", "color": "#40c463" },
+                { "contributionCount": 0, "date": "2024-03-28", "color": "#ebedf0" },
+                { "contributionCount": 1, "date": "2024-03-29", "color": "#9be9a8" },
+                { "contributionCount": 0, "date": "2024-03-30", "color": "#ebedf0" }
+              ]
+            },
+            {
+              "contributionDays": [
+                { "contributionCount": 4, "date": "2024-03-31", "color": "#40c463" },
+                { "contributionCount": 0, "date": "2024-04-01", "color": "#ebedf0" },
+                { "contributionCount": 0, "date": "2024-04-02", "color": "#ebedf0" }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -19,7 +19,7 @@ function makeTestData(): ContributionData {
     }
     weeks.push(week);
   }
-  return { total: 42, weeks };
+  return { total: 42, weeks, source: "html" };
 }
 
 const streak: StreakInfo = { current: 5, max: 10 };


### PR DESCRIPTION
## Summary
- GitHub GraphQL API 지원 추가 (GITHUB_TOKEN 환경변수 또는 `gh auth token` 자동 감지)
- 토큰 실패 시 단계적 fallback: GITHUB_TOKEN → gh auth token → HTML scraping
- 출력 하단에 데이터 소스 표시 (`via GitHub API` / `via HTML scraping`)
- help 텍스트에 데이터 소스 우선순위 설명 추가

## Test plan
- [x] 유효한 토큰으로 GraphQL 경로 동작 확인
- [x] 유효하지 않은 토큰 → fallback 동작 확인
- [x] gh/토큰 없는 컨테이너에서 HTML fallback 확인 (OrbStack)
- [x] 32개 테스트 통과

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)