### PR TITLE
ci: guard npm publish to main branch only

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,14 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Verify tag is on main branch
+        run: |
+          if ! git merge-base --is-ancestor ${{ github.sha }} origin/main; then
+            echo "::error::Tag must be on main branch. Merge to main first, then tag."
+            exit 1
+          fi
       - uses: actions/setup-node@v4
         with:
           node-version: 22


### PR DESCRIPTION
## Summary
- publish 워크플로우에 main 브랜치 체크 추가
- 태그가 main에 포함된 커밋이 아니면 배포 중단
- 작업 브랜치에서 실수로 태그를 달아 미완성 코드가 배포되는 것을 방지

🤖 Generated with [Claude Code](https://claude.com/claude-code)